### PR TITLE
need gio-2.0 2.32

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -36,7 +36,7 @@ else
 fi
 
 AC_MSG_NOTICE([Checking whether to build server])
-PKG_CHECK_MODULES(SNRA_SERVER, [sqlite3 >= 3.3 glib-2.0 >= 2.30],
+PKG_CHECK_MODULES(SNRA_SERVER, [sqlite3 >= 3.3 glib-2.0 >= 2.32],
     [BUILD_SNRA_SERVER=yes], [BUILD_SNRA_SERVER=no])
 AM_CONDITIONAL(BUILD_SNRA_SERVER, test "x$BUILD_SNRA_SERVER" = "xyes")
 


### PR DESCRIPTION
Need gio-2.0 version >= 2.32 to have GSocketClientEvent.
