### PR TITLE
Another compiler warning fix

### DIFF
--- a/src/daemon/snra-manager.c
+++ b/src/daemon/snra-manager.c
@@ -202,7 +202,7 @@ static GstStructure *
 make_player_clients_list_msg (SnraManager * manager)
 {
   GstStructure *msg;
-  GValue p = { 0, };
+  GValue p = G_VALUE_INIT;
   GList *cur;
 
   g_value_init (&p, GST_TYPE_ARRAY);
@@ -213,7 +213,7 @@ make_player_clients_list_msg (SnraManager * manager)
   for (cur = manager->player_info; cur != NULL; cur = g_list_next (cur)) {
     SnraPlayerInfo *info = (SnraPlayerInfo *) (cur->data);
     if (info->conn != NULL) {
-      GValue tmp = { 0, };
+      GValue tmp = G_VALUE_INIT;
       GstStructure *cur_struct = gst_structure_new ("client",
           "client-id", G_TYPE_INT64, (gint64) info->id,
           "enabled", G_TYPE_BOOLEAN, info->enabled,

--- a/src/snra-json.c
+++ b/src/snra-json.c
@@ -26,10 +26,6 @@
 
 #include <src/snra-json.h>
 
-#ifndef G_VALUE_INIT
-#define G_VALUE_INIT {{0,}, {0,}}
-#endif
-
 static void
 snra_json_array_add_to_val (JsonArray *array, guint index_,
     JsonNode *element_node, GValue *outval);


### PR DESCRIPTION
Just use G_VALUE_INIT everywhere and also use it unconditionally
as we depend on GLib >= 2.30 now.

snra-manager.c: In function 'make_player_clients_list_msg':
snra-manager.c:205: warning: missing initializer
snra-manager.c:205: warning: (near initialization for 'p.data')
snra-manager.c:216: warning: missing initializer
snra-manager.c:216: warning: (near initialization for 'tmp.data')
