### PR TITLE
Add support for playing remote URIs

### DIFF
--- a/README
+++ b/README
@@ -23,3 +23,14 @@ Notes/future ideas:
 - player
   + playbin wrapper that does rtsp or http + network clock subscription
     and follows remote volume control, pause/play etc.
+
+
+Security
+========
+
+Very little effort has been put into making the server secure. It may allow
+arbitrary files from the server's file system to be served to clients. No
+authentication is required for clients to connect.
+
+This software should only ever be run on a private network, where all software
+running on the network and its clients is trusted.

--- a/TODO
+++ b/TODO
@@ -2,6 +2,7 @@ Server TODO
  * Track metadata discovery
  * Support seeking.
  * Provide library hooks
+ * Tighten up security
 
 Control UI
  * Song library, searching, enqueueing

--- a/configure.in
+++ b/configure.in
@@ -19,7 +19,7 @@ AC_PROG_CC_STDC
 LT_INIT
 
 PKG_PROG_PKG_CONFIG([0.22])
-PKG_CHECK_MODULES(SNRA_COMMON, [gobject-2.0 glib-2.0 >= 2.30 avahi-client avahi-glib >= 0.6.24 json-glib-1.0 libsoup-2.4 >= 2.26.1])
+PKG_CHECK_MODULES(SNRA_COMMON, [gobject-2.0 glib-2.0 >= 2.30 gio-2.0 avahi-client avahi-glib >= 0.6.24 json-glib-1.0 libsoup-2.4 >= 2.26.1])
 
 AC_MSG_NOTICE([Checking for GStreamer 1.0])
 PKG_CHECK_MODULES(GST_1_0, [gstreamer-1.0 gstreamer-net-1.0 gstreamer-tag-1.0], [HAVE_GST_1_0=yes], [HAVE_GST_1_0=no])

--- a/src/daemon/snra-http-resource.c
+++ b/src/daemon/snra-http-resource.c
@@ -41,7 +41,7 @@ G_DEFINE_TYPE (SnraHttpResource, snra_http_resource, G_TYPE_OBJECT);
 enum
 {
   PROP_0,
-  PROP_SOURCE_PATH,
+  PROP_SOURCE_FILE,
   PROP_LAST
 };
 
@@ -64,14 +64,32 @@ snra_http_resource_open (SnraHttpResource * resource)
     GError *error = NULL;
 
     resources_open++;
-    DEBUG_PRINT ("Opening resource %s. %d now open\n", resource->source_path,
-        resources_open);
-    resource->data = g_mapped_file_new (resource->source_path, FALSE, &error);
-    if (resource->data == NULL) {
-      g_message ("Failed to open resource %s: %s", resource->source_path,
-          error->message);
-      g_error_free (error);
-      return FALSE;
+
+    if (g_file_is_native (resource->source_file)) {
+      gchar *local_path;
+
+      local_path = g_file_get_path (resource->source_file);
+      g_assert (local_path != NULL);
+
+      DEBUG_PRINT ("Opening resource %s. %d now open\n", local_path,
+          resources_open);
+
+      resource->data = g_mapped_file_new (local_path, FALSE, &error);
+
+      if (resource->data == NULL) {
+        g_message ("Failed to open resource %s: %s", local_path,
+            error->message);
+        g_error_free (error);
+        g_free (local_path);
+        resources_open--;
+
+        return FALSE;
+      }
+
+      g_free (local_path);
+    } else {
+      /* Non-native files can't be mmap()ped. */
+      resource->data = NULL;
     }
   }
   g_object_ref (resource);
@@ -86,19 +104,30 @@ snra_http_resource_close (SnraHttpResource * resource)
     resource->use_count--;
     if (resource->use_count == 0) {
       resources_open--;
-      DEBUG_PRINT ("Releasing resource %s. %d now open\n", resource->source_path,
-          resources_open);
+
+      if (g_file_is_native (resource->source_file)) {
+        gchar *local_path;
+
+        /* Release the mmap() on the local file. */
+        local_path = g_file_get_path (resource->source_file);
+        DEBUG_PRINT ("Releasing resource %s. %d now open\n", local_path,
+            resources_open);
 #if GLIB_CHECK_VERSION(2,22,0)
-      g_mapped_file_unref (resource->data);
+        g_mapped_file_unref (resource->data);
 #else
-      g_mapped_file_free (resource->data);
+        g_mapped_file_free (resource->data);
 #endif
-      resource->data = NULL;
+        resource->data = NULL;
+
+        DEBUG_PRINT ("closed resource %s (%p) use count now %d\n",
+            local_path, resource, resource->use_count);
+        g_free (local_path);
+      } else {
+        /* Non-native file. */
+        resource->data = NULL;
+      }
     }
   }
-
-  DEBUG_PRINT ("closed resource %s (%p) use count now %d\n",
-      resource->source_path, resource, resource->use_count);
 
   g_object_unref (resource);
 }
@@ -114,8 +143,8 @@ snra_transfer_new (SnraHttpResource *resource)
   transfer = g_new0 (SnraTransfer, 1);
   transfer->resource = g_object_ref (resource);
 
-  DEBUG_PRINT ("Started transfer with resource %s (%p) use count now %d\n",
-      resource->source_path, resource, resource->use_count);
+  DEBUG_PRINT ("Started transfer with resource %p use count now %d\n",
+      resource, resource->use_count);
 
   return transfer;
 }
@@ -125,8 +154,8 @@ snra_transfer_free (SnraTransfer *transfer)
 {
   snra_http_resource_close (transfer->resource);
 
-  DEBUG_PRINT ("Completed transfer of %s. Use count now %d\n",
-      transfer->resource->source_path, transfer->resource->use_count);
+  DEBUG_PRINT ("Completed transfer of %p. Use count now %d\n",
+      transfer->resource, transfer->resource->use_count);
 
   g_object_unref (transfer->resource);
   g_free (transfer);
@@ -139,6 +168,22 @@ snra_http_resource_new_transfer (SnraHttpResource * resource, SoupMessage * msg)
    * resource to it */
   SnraTransfer *transfer;
   SoupBuffer *buffer;
+  gchar *local_path;
+
+  /* Non-local files are implemented as a HTTP redirect.
+   *
+   * FIXME: This isn't an ideal solution, as clients may not be able to access
+   * exactly the same resources as the server (due to network configuration or
+   * access restrictions). It would be better to proxy the file through the
+   * daemon, but that's an order of magnitude more complex than a simple HTTP
+   * redirect. */
+  if (!g_file_is_native (resource->source_file)) {
+    gchar *resource_uri = g_file_get_uri (resource->source_file);
+    soup_message_set_redirect (msg, SOUP_STATUS_TEMPORARY_REDIRECT, resource_uri);
+    g_free (resource_uri);
+
+    return;
+  }
 
   transfer = snra_transfer_new (resource);
 
@@ -147,6 +192,9 @@ snra_http_resource_new_transfer (SnraHttpResource * resource, SoupMessage * msg)
     return;
   }
 
+  local_path = g_file_get_path (resource->source_file);
+  g_assert (local_path != NULL);
+
   buffer = soup_buffer_new_with_owner (
       g_mapped_file_get_contents (transfer->resource->data),
       g_mapped_file_get_length (transfer->resource->data),
@@ -154,9 +202,11 @@ snra_http_resource_new_transfer (SnraHttpResource * resource, SoupMessage * msg)
 
   soup_message_set_status (msg, SOUP_STATUS_OK);
   soup_message_headers_replace (msg->response_headers,
-      "Content-Type", snra_resource_get_mime_type (resource->source_path));
+      "Content-Type", snra_resource_get_mime_type (local_path));
   soup_message_body_append_buffer (msg->response_body, buffer);
   soup_buffer_free (buffer);
+
+  g_free (local_path);
 }
 
 static void
@@ -172,9 +222,9 @@ snra_http_resource_class_init (SnraHttpResourceClass * resource_class)
   gobject_class->set_property = snra_http_resource_set_property;
   gobject_class->get_property = snra_http_resource_get_property;
 
-  g_object_class_install_property (gobject_class, PROP_SOURCE_PATH,
-      g_param_spec_string ("source-path", "Source Path",
-          "Source file path resource", NULL, G_PARAM_READWRITE));
+  g_object_class_install_property (gobject_class, PROP_SOURCE_FILE,
+      g_param_spec_object ("source-file", "Source File",
+          "Source file resource", G_TYPE_FILE, G_PARAM_READWRITE));
 }
 
 static void
@@ -184,9 +234,9 @@ snra_http_resource_set_property (GObject * object, guint prop_id,
   SnraHttpResource *resource = (SnraHttpResource *) (object);
 
   switch (prop_id) {
-    case PROP_SOURCE_PATH:
-      g_free (resource->source_path);
-      resource->source_path = g_value_dup_string (value);
+    case PROP_SOURCE_FILE:
+      g_clear_object (&resource->source_file);
+      resource->source_file = g_value_dup_object (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -201,8 +251,8 @@ snra_http_resource_get_property (GObject * object, guint prop_id,
   SnraHttpResource *resource = (SnraHttpResource *) (object);
 
   switch (prop_id) {
-    case PROP_SOURCE_PATH:
-      g_value_set_string (value, resource->source_path);
+    case PROP_SOURCE_FILE:
+      g_value_set_object (value, resource->source_file);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/src/daemon/snra-http-resource.h
+++ b/src/daemon/snra-http-resource.h
@@ -36,7 +36,7 @@ struct _SnraHttpResource
 {
   GObject parent;
 
-  gchar *source_path;
+  GFile *source_file;
   guint use_count;
   GMappedFile *data;
 };

--- a/src/daemon/snra-manager.c
+++ b/src/daemon/snra-manager.c
@@ -538,7 +538,14 @@ control_callback (G_GNUC_UNUSED SoupServer * soup, SoupMessage * msg,
 
       g_print ("Next ID %s\n", id_str);
 
-      if (id_str && id_str[0] == '/') {
+      /* Accept two forms of ID. If the ID can be parsed as an integer, use it
+       * to look up a file in the media DB and enqueue that. Otherwise, treat
+       * the ID as a URI and use the manager's custom_file functionality to
+       * enqueue that URI (which probably isn't in the media DB). Custom files
+       * are signified by the resource ID G_MAXUINT. Note that URIs may be
+       * fully qualified URIs, or absolute paths on the server (beginning with
+       * '/'). */
+      if (id_str && !g_ascii_isdigit (id_str[0])) {
         resource_id = G_MAXUINT;
         g_clear_object (&manager->custom_file);
         manager->custom_file = g_file_new_for_commandline_arg (id_str);

--- a/src/daemon/snra-manager.c
+++ b/src/daemon/snra-manager.c
@@ -540,8 +540,8 @@ control_callback (G_GNUC_UNUSED SoupServer * soup, SoupMessage * msg,
 
       if (id_str && id_str[0] == '/') {
         resource_id = G_MAXUINT;
-        g_free (manager->custom_file);
-        manager->custom_file = g_strdup (id_str);
+        g_clear_object (&manager->custom_file);
+        manager->custom_file = g_file_new_for_commandline_arg (id_str);
       } else if (get_playlist_len (manager) == 0) {
         resource_id = 0;
       } else if (id_str == NULL || !id_str[0]
@@ -749,7 +749,7 @@ snra_manager_finalize (GObject * object)
   snra_server_stop (manager->server);
   g_object_unref (manager->server);
 
-  g_free (manager->custom_file);
+  g_clear_object (&manager->custom_file);
   g_free (manager->language);
 }
 
@@ -906,7 +906,7 @@ snra_manager_get_resource_cb (G_GNUC_UNUSED SnraServer * server,
   gchar *file_uri;
 
   if (resource_id == G_MAXUINT && manager->custom_file)
-    return g_object_new (SNRA_TYPE_HTTP_RESOURCE, "source-path",
+    return g_object_new (SNRA_TYPE_HTTP_RESOURCE, "source-file",
         manager->custom_file, NULL);
 
   if (resource_id < 1 || resource_id > get_playlist_len (manager))
@@ -920,7 +920,7 @@ snra_manager_get_resource_cb (G_GNUC_UNUSED SnraServer * server,
   g_print ("Creating resource %u for %s\n", resource_id, file_uri);
   g_free (file_uri);
 
-  ret = g_object_new (SNRA_TYPE_HTTP_RESOURCE, "source-path", file, NULL);
+  ret = g_object_new (SNRA_TYPE_HTTP_RESOURCE, "source-file", file, NULL);
   g_object_unref (file);
 
   return ret;

--- a/src/daemon/snra-manager.c
+++ b/src/daemon/snra-manager.c
@@ -544,7 +544,11 @@ control_callback (G_GNUC_UNUSED SoupServer * soup, SoupMessage * msg,
        * enqueue that URI (which probably isn't in the media DB). Custom files
        * are signified by the resource ID G_MAXUINT. Note that URIs may be
        * fully qualified URIs, or absolute paths on the server (beginning with
-       * '/'). */
+       * '/').
+       *
+       * FIXME: Allowing arbitrary files to be loaded from anywhere in the
+       * server's file system (that aurena-server has access to) is wide open
+       * to abuse. See the note in README for a disclaimer. */
       if (id_str && !g_ascii_isdigit (id_str[0])) {
         resource_id = G_MAXUINT;
         g_clear_object (&manager->custom_file);

--- a/src/daemon/snra-manager.h
+++ b/src/daemon/snra-manager.h
@@ -56,7 +56,7 @@ struct _SnraManager
   GPtrArray *playlist;
   gboolean paused;
   guint current_resource;
-  gchar *custom_file;
+  GFile *custom_file;
   gchar *language;
 
   guint next_player_id;

--- a/src/daemon/snra-media-db.c
+++ b/src/daemon/snra-media-db.c
@@ -17,6 +17,19 @@
  * Boston, MA 02111-1307, USA.
  */
 
+/*
+ * Media database interface.
+ *
+ * The database has three tables: files, paths and songs. The songs table isn't
+ * used at all. The files and paths tables store paths and basenames for media
+ * files, split up to reduce path duplication. However, URIs may also be stored
+ * in the database, in a slightly different format. In the case of storing
+ * normal paths or local URIs, the path and basename are calculated and split
+ * between the files and paths tables. The files.base_path_id is positive. In
+ * the case of storing non-local URIs, the entire URI is stored in
+ * files.filename and files.base_path_id is 0.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -286,20 +299,34 @@ done:
 }
 
 void
-snra_media_db_add_file (SnraMediaDB * media_db, const gchar * filename)
+snra_media_db_add_file (SnraMediaDB * media_db, GFile *file)
 {
-  gchar *path = g_path_get_dirname (filename);
-  gchar *file = g_path_get_basename (filename);
+  gchar *basename;
   guint64 path_id;
 
-  path_id = snra_media_path_to_id (media_db, path);
-  snra_media_file_to_id (media_db, path_id, file);
+  if (g_file_is_native (file)) {
+    gchar *filename, *dirname;
 
-  //g_print ("File %s has id %" G_GUINT64_FORMAT "\n",
-  //filename, file_id);
+    /* Old-style local file. Split it into its basename and filename and
+     * insert them into different tables. */
+    filename = g_file_get_path (file);
+    dirname = g_path_get_dirname (filename);
 
-  g_free (path);
-  g_free (file);
+    path_id = snra_media_path_to_id (media_db, dirname);
+    basename = g_path_get_basename (filename);
+
+    g_free (dirname);
+    g_free (filename);
+  } else {
+    /* New-style URI. Insert the entire URI into the files table with a path ID
+     * of 0 to indicate it has no associated entry in the paths table. */
+    basename = g_file_get_uri (file);
+    path_id = 0;
+  }
+
+  snra_media_file_to_id (media_db, path_id, basename);
+
+  g_free (basename);
 }
 
 guint
@@ -323,7 +350,7 @@ done:
   return count;
 }
 
-gchar *
+GFile *
 snra_media_db_get_file_by_id (SnraMediaDB * media_db, guint id)
 {
   sqlite3_stmt *stmt = NULL;
@@ -334,8 +361,9 @@ snra_media_db_get_file_by_id (SnraMediaDB * media_db, guint id)
     goto done;
 
   if (sqlite3_prepare (handle,
-          "select base_path, filename from paths, files where paths.id = files.base_path_id "
-          "limit 1 offset ?", -1, &stmt, NULL) != SQLITE_OK)
+          "select base_path, filename, files.base_path_id from paths, files where "
+          "(paths.id = files.base_path_id or files.base_path_id = 0) and files.id = ?"
+          "limit 1", -1, &stmt, NULL) != SQLITE_OK)
     goto done;
 
   if (sqlite3_bind_int64 (stmt, 1, id - 1) != SQLITE_OK)
@@ -343,12 +371,26 @@ snra_media_db_get_file_by_id (SnraMediaDB * media_db, guint id)
 
   if (sqlite3_step (stmt) == SQLITE_ROW) {
     const gchar *base_path, *filename;
-    base_path = (gchar *) sqlite3_column_text (stmt, 0);
-    filename = (gchar *) sqlite3_column_text (stmt, 1);
-    ret_path = g_build_filename (base_path, filename, NULL);
+    gint base_path_id;
+
+    base_path_id = sqlite3_column_int (stmt, 2);
+
+    if (base_path_id > 0) {
+      /* Old-style local file. */
+      base_path = (gchar *) sqlite3_column_text (stmt, 0);
+      filename = (gchar *) sqlite3_column_text (stmt, 1);
+      ret_path = g_build_filename (base_path, filename, NULL);
+    } else {
+      /* New-style URI. The base_path is empty. */
+      ret_path = g_strdup ((char *) sqlite3_column_text (stmt, 1));
+    }
+
     goto done;
   }
 
 done:
-  return ret_path;
+  if (ret_path == NULL)
+    return NULL;
+
+  return g_file_new_for_path (ret_path);
 }

--- a/src/daemon/snra-media-db.h
+++ b/src/daemon/snra-media-db.h
@@ -22,6 +22,7 @@
 
 #include <glib.h>
 #include <glib-object.h>
+#include <gio/gio.h>
 #include <sqlite3.h>
 
 #include <src/snra-types.h>
@@ -37,9 +38,9 @@ struct _SnraMediaDB
 };
 
 SnraMediaDB *snra_media_db_new(const char *db_path);
-void snra_media_db_add_file (SnraMediaDB *media_db, const gchar *filename);
+void snra_media_db_add_file (SnraMediaDB *media_db, GFile *file);
 guint snra_media_db_get_file_count (SnraMediaDB *media_db);
-gchar *snra_media_db_get_file_by_id (SnraMediaDB *media_db, guint id);
+GFile *snra_media_db_get_file_by_id (SnraMediaDB *media_db, guint id);
 
 G_END_DECLS
 


### PR DESCRIPTION
Here’s a branch which adds support for Aurena to play back remote URIs, both from the playlist and via the custom_file code. It modifies the database format slightly (partially deprecating the ‘paths’ table) and also modifies the URI format for /control/next so that it can accept full URIs as IDs (as well as traditional integer IDs).

It adds a dependency on GIO, but that shouldn’t be a problem since Aurena depended on a recent-enough version of GLib anyway.

It also amends the README to mention that Aurena is not to be considered secure, because it allows arbitrary URIs on the server to be sent to the clients.
